### PR TITLE
run the set_current_revision on the local_cache

### DIFF
--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -74,7 +74,9 @@ namespace "rsync" do
 
   task :set_current_revision do
     run_locally do
-      set :current_revision, capture(:git, 'rev-parse', fetch(:branch))
+      within fetch(:local_cache) do
+        set :current_revision, capture(:git, 'rev-parse', fetch(:branch))
+      end
     end
   end
 


### PR DESCRIPTION
because there is no git repo at the root of my capistrano folder.
For prevent error : git stderr: fatal: ambiguous argument 'master': unknown revision or path not in the working tree.
